### PR TITLE
add status results

### DIFF
--- a/pyVTTrac/VTTrac.py
+++ b/pyVTTrac/VTTrac.py
@@ -272,7 +272,7 @@ class VTT:
         y0 = np.asarray(y0) + 1
 
         results = Main.VTTrac.trac(self.o, tid0, x0, y0, vxg=vxg0, vyg=vyg0, out_subimage=out_subimage, out_score_ary=out_score_ary, to_missing=False)
-        count, tid, x, y, vx, vy, score, zss, score_ary = results
+        count, status, tid, x, y, vx, vy, score, zss, score_ary = results
 
         # Python is 0-origin, so -1
         tid0 -= 1
@@ -281,6 +281,7 @@ class VTT:
 
         # assign missing value
         count = np.array(count)
+        status = np.array(status)
         tid = np.array(tid).astype(float)
         tid[tid==self.imiss] = np.nan
         x = np.array(x)
@@ -301,12 +302,12 @@ class VTT:
             score_ary[score_ary==self.fmiss] = np.nan
 
         if asxarray:
-            ds = self.to_xarray(count, tid, x, y, vx, vy, score, zss, score_ary, out_subimage=out_subimage, out_score_ary=out_score_ary)
+            ds = self.to_xarray(count, status, tid, x, y, vx, vy, score, zss, score_ary, out_subimage=out_subimage, out_score_ary=out_score_ary)
             return ds
         else:
-            return count, tid, x, y, vx, vy, score, zss, score_ary
+            return count, status, tid, x, y, vx, vy, score, zss, score_ary
 
-    def to_xarray(self, count, tid, x, y, vx, vy, score, zss=None, score_ary=None, out_subimage=False, out_score_ary=False):
+    def to_xarray(self, count, status, tid, x, y, vx, vy, score, zss=None, score_ary=None, out_subimage=False, out_score_ary=False):
         sh = count.shape
         dims = [None]*len(sh)
         dimnames = [""]*len(sh)
@@ -317,6 +318,7 @@ class VTT:
             data_vars=dict(
                 z = (["t", "y", "x"], self.o.z),
                 count = (dimnames, count),
+                status = (dimnames, status),
                 tid = (["it_rel", *dimnames], tid),
                 xloc = (["it_rel", *dimnames], x),
                 yloc = (["it_rel", *dimnames], y),
@@ -368,7 +370,7 @@ class VTT:
         y = (y-self.y0)/self.dy
 
         opts["asxarray"] = False
-        count, tid, x, y, vx, vy, score, zss, score_ary = self.trac(tid0, x, y, **opts)
+        count, status, tid, x, y, vx, vy, score, zss, score_ary = self.trac(tid0, x, y, **opts)
 
         x = x * self.dx + self.x0
         y = y * self.dy + self.y0
@@ -378,5 +380,5 @@ class VTT:
         else:
             vx = vx * (self.ucfact*self.dx)
             vy = vy * (self.ucfact*self.dy)
-        ds = self.to_xarray(count, tid, x, y, vx, vy, score, zss, score_ary)
+        ds = self.to_xarray(count, status, tid, x, y, vx, vy, score, zss, score_ary)
         return ds


### PR DESCRIPTION
### PR description
This PR adds a new result variable named `status` to distinguish why tracking has stopped.
The `status` has the same shape as `count` and contains a number from 0 to 9 for each tracking point.

Meanings of the numbers are follow:

* 0: Alive
* 1: Stop at `inspect_t_index` of `tidf`
* 2: Stop at `get_zsub_subgrid`
* 3: Stop at `min_contrast` check
* 4: Stop at `chk_zsub_peak_inside`
* 5: Stop at `inspect_t_index` of `tidl`
* 6: Stop at `get_score`
* 7: Stop at `find_score_peak`
* 8: Stop at `score_th0` or `score_th1` check
* 9: Stop at `chk_vchange`

### Note
These numbers are in order of implementation, so if a tracking point has a status number of `3`, the tracking may be stopped for other reasons after `3`.